### PR TITLE
Update to TF plugin framework v1

### DIFF
--- a/gen/github.com/zitadel/zitadel/pkg/grpc/text/text_terraform.go
+++ b/gen/github.com/zitadel/zitadel/pkg/grpc/text/text_terraform.go
@@ -29,7 +29,7 @@ import (
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
 	github_com_hashicorp_terraform_plugin_framework_attr "github.com/hashicorp/terraform-plugin-framework/attr"
 	github_com_hashicorp_terraform_plugin_framework_diag "github.com/hashicorp/terraform-plugin-framework/diag"
-	github_com_hashicorp_terraform_plugin_framework_tfsdk "github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	github_com_hashicorp_terraform_plugin_framework_schema "github.com/hashicorp/terraform-plugin-framework/schema"
 	github_com_hashicorp_terraform_plugin_framework_types "github.com/hashicorp/terraform-plugin-framework/types"
 	github_com_hashicorp_terraform_plugin_go_tftypes "github.com/hashicorp/terraform-plugin-go/tftypes"
 )
@@ -39,11 +39,11 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-// GenSchemaLoginCustomText returns tfsdk.Schema definition for LoginCustomText
-func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terraform_plugin_framework_tfsdk.Schema, github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics) {
-	return github_com_hashicorp_terraform_plugin_framework_tfsdk.Schema{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+// GenSchemaLoginCustomText returns schema.Schema definition for LoginCustomText
+func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terraform_plugin_framework_schema.Schema, github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics) {
+	return github_com_hashicorp_terraform_plugin_framework_schema.Schema{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 		"email_verification_done_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"cancel_button_text": {
 					Description: "",
 					Optional:    true,
@@ -74,7 +74,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"email_verification_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"code_label": {
 					Description: "",
 					Optional:    true,
@@ -105,7 +105,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"external_registration_user_overview_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"back_button_text": {
 					Description: "",
 					Optional:    true,
@@ -191,7 +191,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"external_user_not_found_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"auto_register_button_text": {
 					Description: "",
 					Optional:    true,
@@ -242,7 +242,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"footer_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"help": {
 					Description: "",
 					Optional:    true,
@@ -274,7 +274,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Type:     github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"init_mfa_done_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"cancel_button_text": {
 					Description: "",
 					Optional:    true,
@@ -300,7 +300,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"init_mfa_otp_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"cancel_button_text": {
 					Description: "",
 					Optional:    true,
@@ -341,7 +341,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"init_mfa_prompt_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"description": {
 					Description: "",
 					Optional:    true,
@@ -377,7 +377,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"init_mfa_u2f_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"description": {
 					Description: "",
 					Optional:    true,
@@ -413,7 +413,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"init_password_done_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"cancel_button_text": {
 					Description: "",
 					Optional:    true,
@@ -439,7 +439,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"init_password_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"code_label": {
 					Description: "",
 					Optional:    true,
@@ -480,7 +480,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"initialize_done_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"cancel_button_text": {
 					Description: "",
 					Optional:    true,
@@ -506,7 +506,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"initialize_user_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"code_label": {
 					Description: "",
 					Optional:    true,
@@ -553,7 +553,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Type:     github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"linking_user_done_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"cancel_button_text": {
 					Description: "",
 					Optional:    true,
@@ -579,7 +579,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"linking_user_prompt_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"description": {
 					Description: "",
 					Optional:    true,
@@ -605,7 +605,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"login_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"description": {
 					Description: "",
 					Optional:    true,
@@ -666,7 +666,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"logout_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"description": {
 					Description: "",
 					Optional:    true,
@@ -687,7 +687,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"mfa_providers_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"choose_other": {
 					Description: "",
 					Optional:    true,
@@ -714,7 +714,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Type:     github_com_hashicorp_terraform_plugin_framework_types.StringType,
 		},
 		"password_change_done_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"description": {
 					Description: "",
 					Optional:    true,
@@ -735,7 +735,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"password_change_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"cancel_button_text": {
 					Description: "",
 					Optional:    true,
@@ -781,7 +781,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"password_reset_done_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"description": {
 					Description: "",
 					Optional:    true,
@@ -802,7 +802,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"password_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"back_button_text": {
 					Description: "",
 					Optional:    true,
@@ -868,7 +868,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"passwordless_prompt_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"description": {
 					Description: "",
 					Optional:    true,
@@ -904,7 +904,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"passwordless_registration_done_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"cancel_button_text": {
 					Description: "",
 					Optional:    true,
@@ -935,7 +935,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"passwordless_registration_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"description": {
 					Description: "",
 					Optional:    true,
@@ -971,7 +971,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"passwordless_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"description": {
 					Description: "",
 					Optional:    true,
@@ -1007,7 +1007,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"registration_option_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"description": {
 					Description: "",
 					Optional:    true,
@@ -1038,7 +1038,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"registration_org_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"description": {
 					Description: "",
 					Optional:    true,
@@ -1119,7 +1119,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"registration_user_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"back_button_text": {
 					Description: "",
 					Optional:    true,
@@ -1215,7 +1215,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"select_account_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"description": {
 					Description: "",
 					Optional:    true,
@@ -1261,7 +1261,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"success_login_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"auto_redirect_description": {
 					Description: "Text to describe that auto-redirect should happen after successful login",
 					Optional:    true,
@@ -1287,7 +1287,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"username_change_done_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"description": {
 					Description: "",
 					Optional:    true,
@@ -1308,7 +1308,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"username_change_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"cancel_button_text": {
 					Description: "",
 					Optional:    true,
@@ -1339,7 +1339,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"verify_mfa_otp_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"code_label": {
 					Description: "",
 					Optional:    true,
@@ -1365,7 +1365,7 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 			Optional:    true,
 		},
 		"verify_mfa_u2f_text": {
-			Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+			Attributes: github_com_hashicorp_terraform_plugin_framework_schema.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 				"description": {
 					Description: "",
 					Optional:    true,
@@ -1398,9 +1398,9 @@ func GenSchemaLoginCustomText(ctx context.Context) (github_com_hashicorp_terrafo
 	}}, nil
 }
 
-// GenSchemaMessageCustomText returns tfsdk.Schema definition for MessageCustomText
-func GenSchemaMessageCustomText(ctx context.Context) (github_com_hashicorp_terraform_plugin_framework_tfsdk.Schema, github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics) {
-	return github_com_hashicorp_terraform_plugin_framework_tfsdk.Schema{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+// GenSchemaMessageCustomText returns schema.Schema definition for MessageCustomText
+func GenSchemaMessageCustomText(ctx context.Context) (github_com_hashicorp_terraform_plugin_framework_schema.Schema, github_com_hashicorp_terraform_plugin_framework_diag.Diagnostics) {
+	return github_com_hashicorp_terraform_plugin_framework_schema.Schema{Attributes: map[string]github_com_hashicorp_terraform_plugin_framework_schema.Attribute{
 		"button_text": {
 			Description: "",
 			Optional:    true,

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/hcl/v2 v2.16.2
-	github.com/hashicorp/terraform-plugin-framework v0.15.0
+        github.com/hashicorp/terraform-plugin-framework v1.7.0
 	github.com/hashicorp/terraform-plugin-go v0.14.3
 	github.com/hashicorp/terraform-plugin-log v0.8.0
 	github.com/hashicorp/terraform-plugin-mux v0.7.0

--- a/main.go
+++ b/main.go
@@ -6,10 +6,6 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
-	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
-	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 
 	"github.com/zitadel/terraform-provider-zitadel/v2/zitadel"
 )
@@ -21,28 +17,12 @@ func main() {
 	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
-	upgradedSdkProvider, err := tf5to6server.UpgradeServer(ctx, zitadel.Provider().GRPCProvider)
-	if err != nil {
+	opts := providerserver.ServeOpts{
+		Address: "registry.terraform.io/zitadel/zitadel",
+		Debug:   debug,
+	}
+
+	if err := providerserver.Serve(ctx, zitadel.NewProviderPV6, opts); err != nil {
 		log.Fatal(err)
-	}
-
-	providers := []func() tfprotov6.ProviderServer{
-		func() tfprotov6.ProviderServer {
-			return upgradedSdkProvider
-		},
-		providerserver.NewProtocol6(zitadel.NewProviderPV6()),
-	}
-
-	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
-
-	opts := []tf6server.ServeOpt{}
-	if debug {
-		opts = append(opts, tf6server.WithManagedDebug())
-	}
-
-	err = tf6server.Serve("registry.terraform.io/zitadel/zitadel", muxServer.ProviderServer, opts...)
-
-	if err != nil {
-		log.Fatalln(err.Error())
 	}
 }

--- a/zitadel/default_domain_claimed_message_text/resource.go
+++ b/zitadel/default_domain_claimed_message_text/resource.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/admin"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -37,7 +37,7 @@ func (r *defaultDomainClaimedMessageTextResource) Metadata(_ context.Context, re
 	resp.TypeName = req.ProviderTypeName + "_default_domain_claimed_message_text"
 }
 
-func (r *defaultDomainClaimedMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *defaultDomainClaimedMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	s, d := text.GenSchemaMessageCustomText(ctx)
 	delete(s.Attributes, "org_id")
 	return s, d
@@ -215,7 +215,7 @@ func getID(ctx context.Context, obj types.Object) string {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), "id")
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) string {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) string {
 
 	var language string
 	diag.Append(plan.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
@@ -226,7 +226,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) s
 	return language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) string {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(state.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {

--- a/zitadel/default_init_message_text/resource.go
+++ b/zitadel/default_init_message_text/resource.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/admin"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -37,7 +37,7 @@ func (r *defaultInitMessageTextResource) Metadata(_ context.Context, req resourc
 	resp.TypeName = req.ProviderTypeName + "_default_init_message_text"
 }
 
-func (r *defaultInitMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *defaultInitMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	s, d := text.GenSchemaMessageCustomText(ctx)
 	delete(s.Attributes, "org_id")
 	return s, d
@@ -215,7 +215,7 @@ func getID(ctx context.Context, obj types.Object) string {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), "id")
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) string {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(plan.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {
@@ -224,7 +224,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) s
 	return language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) string {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(state.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {

--- a/zitadel/default_login_texts/resource.go
+++ b/zitadel/default_login_texts/resource.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/admin"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -37,7 +37,7 @@ func (r *defaultLoginTextsResource) Metadata(_ context.Context, req resource.Met
 	resp.TypeName = req.ProviderTypeName + "_default_login_texts"
 }
 
-func (r *defaultLoginTextsResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *defaultLoginTextsResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	s, d := text.GenSchemaLoginCustomText(ctx)
 	delete(s.Attributes, "org_id")
 	return s, d
@@ -215,7 +215,7 @@ func getID(ctx context.Context, obj types.Object) string {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), "id")
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) string {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(plan.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {
@@ -224,7 +224,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) s
 	return language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) string {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(state.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {

--- a/zitadel/default_password_change_message_text/resource.go
+++ b/zitadel/default_password_change_message_text/resource.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/admin"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -37,7 +37,7 @@ func (r *defaultPasswordChangeMessageTextResource) Metadata(_ context.Context, r
 	resp.TypeName = req.ProviderTypeName + "_default_password_change_message_text"
 }
 
-func (r *defaultPasswordChangeMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *defaultPasswordChangeMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	s, d := text.GenSchemaMessageCustomText(ctx)
 	delete(s.Attributes, "org_id")
 	return s, d
@@ -215,7 +215,7 @@ func getID(ctx context.Context, obj types.Object) string {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), "id")
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) string {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(plan.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {
@@ -224,7 +224,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) s
 	return language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) string {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(state.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {

--- a/zitadel/default_password_reset_message_text/resource.go
+++ b/zitadel/default_password_reset_message_text/resource.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/admin"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -37,7 +37,7 @@ func (r *defaultPasswordResetMessageTextResource) Metadata(_ context.Context, re
 	resp.TypeName = req.ProviderTypeName + "_default_password_reset_message_text"
 }
 
-func (r *defaultPasswordResetMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *defaultPasswordResetMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	s, d := text.GenSchemaMessageCustomText(ctx)
 	delete(s.Attributes, "org_id")
 	return s, d
@@ -215,7 +215,7 @@ func getID(ctx context.Context, obj types.Object) string {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), "id")
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) string {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(plan.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {
@@ -224,7 +224,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) s
 	return language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) string {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(state.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {

--- a/zitadel/default_passwordless_registration_message_text/resource.go
+++ b/zitadel/default_passwordless_registration_message_text/resource.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/admin"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -37,7 +37,7 @@ func (r *defaultPasswordlessRegistrationMessageTextResource) Metadata(_ context.
 	resp.TypeName = req.ProviderTypeName + "_default_passwordless_registration_message_text"
 }
 
-func (r *defaultPasswordlessRegistrationMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *defaultPasswordlessRegistrationMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	s, d := text.GenSchemaMessageCustomText(ctx)
 	delete(s.Attributes, "org_id")
 	return s, d
@@ -215,7 +215,7 @@ func getID(ctx context.Context, obj types.Object) string {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), "id")
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) string {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(plan.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {
@@ -224,7 +224,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) s
 	return language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) string {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(state.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {

--- a/zitadel/default_verify_email_message_text/resource.go
+++ b/zitadel/default_verify_email_message_text/resource.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/admin"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -37,7 +37,7 @@ func (r *defaultVerifyEmailMessageTextResource) Metadata(_ context.Context, req 
 	resp.TypeName = req.ProviderTypeName + "_default_verify_email_message_text"
 }
 
-func (r *defaultVerifyEmailMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *defaultVerifyEmailMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	s, d := text.GenSchemaMessageCustomText(ctx)
 	delete(s.Attributes, "org_id")
 	return s, d
@@ -215,7 +215,7 @@ func getID(ctx context.Context, obj types.Object) string {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), "id")
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) string {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(plan.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {
@@ -224,7 +224,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) s
 	return language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) string {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(state.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {

--- a/zitadel/default_verify_email_otp_message_text/resource.go
+++ b/zitadel/default_verify_email_otp_message_text/resource.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/admin"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -37,7 +37,7 @@ func (r *defaultVerifyEmailOTPMessageTextResource) Metadata(_ context.Context, r
 	resp.TypeName = req.ProviderTypeName + "_default_verify_email_otp_message_text"
 }
 
-func (r *defaultVerifyEmailOTPMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *defaultVerifyEmailOTPMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	s, d := text.GenSchemaMessageCustomText(ctx)
 	delete(s.Attributes, "org_id")
 	return s, d
@@ -215,7 +215,7 @@ func getID(ctx context.Context, obj types.Object) string {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), "id")
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) string {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(plan.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {
@@ -224,7 +224,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) s
 	return language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) string {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(state.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {

--- a/zitadel/default_verify_phone_message_text/resource.go
+++ b/zitadel/default_verify_phone_message_text/resource.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/admin"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -37,7 +37,7 @@ func (r *defaultVerifyPhoneMessageTextResource) Metadata(_ context.Context, req 
 	resp.TypeName = req.ProviderTypeName + "_default_verify_phone_message_text"
 }
 
-func (r *defaultVerifyPhoneMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *defaultVerifyPhoneMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	s, d := text.GenSchemaMessageCustomText(ctx)
 	delete(s.Attributes, "org_id")
 	return s, d
@@ -215,7 +215,7 @@ func getID(ctx context.Context, obj types.Object) string {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), "id")
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) string {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(plan.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {
@@ -224,7 +224,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) s
 	return language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) string {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(state.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {

--- a/zitadel/default_verify_sms_otp_message_text/resource.go
+++ b/zitadel/default_verify_sms_otp_message_text/resource.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/admin"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -37,7 +37,7 @@ func (r *defaultVerifySMSOTPMessageTextResource) Metadata(_ context.Context, req
 	resp.TypeName = req.ProviderTypeName + "_default_verify_sms_otp_message_text"
 }
 
-func (r *defaultVerifySMSOTPMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *defaultVerifySMSOTPMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	s, d := text.GenSchemaMessageCustomText(ctx)
 	delete(s.Attributes, "org_id")
 	return s, d
@@ -215,7 +215,7 @@ func getID(ctx context.Context, obj types.Object) string {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), "id")
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) string {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(plan.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {
@@ -224,7 +224,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) s
 	return language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) string {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) string {
 	var language string
 	diag.Append(state.GetAttribute(ctx, path.Root(LanguageVar), &language)...)
 	if diag.HasError() {

--- a/zitadel/domain_claimed_message_text/resource.go
+++ b/zitadel/domain_claimed_message_text/resource.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -38,7 +38,7 @@ func (r *domainClaimedMessageTextResource) Metadata(_ context.Context, req resou
 	resp.TypeName = req.ProviderTypeName + "_domain_claimed_message_text"
 }
 
-func (r *domainClaimedMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *domainClaimedMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	return text.GenSchemaMessageCustomText(ctx)
 }
 
@@ -220,7 +220,7 @@ func getID(ctx context.Context, obj types.Object) (string, string) {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), helper.OrgIDVar), helper.GetStringFromAttr(ctx, obj.Attributes(), LanguageVar)
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (string, string) {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(plan.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {
@@ -235,7 +235,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (
 	return orgID, language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) (string, string) {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(state.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {

--- a/zitadel/helper/test_utils/base_frame.go
+++ b/zitadel/helper/test_utils/base_frame.go
@@ -5,10 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
-	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -67,22 +64,7 @@ KEY
 	}
 	frame.v6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
 		"zitadel": func() (tfprotov6.ProviderServer, error) {
-			muxServer, err := tf6muxserver.NewMuxServer(frame,
-				providerserver.NewProtocol6(zitadel.NewProviderPV6()),
-				func() tfprotov6.ProviderServer {
-					upgraded, err := tf5to6server.UpgradeServer(frame, func() tfprotov5.ProviderServer {
-						return zitadelProvider.GRPCProvider()
-					})
-					if err != nil {
-						return nil
-					}
-					return upgraded
-				},
-			)
-			if err != nil {
-				return nil, err
-			}
-			return muxServer.ProviderServer(), nil
+			return providerserver.NewProtocol6(zitadel.NewProviderPV6()), nil
 		},
 	}
 	return frame, nil

--- a/zitadel/init_message_text/resource.go
+++ b/zitadel/init_message_text/resource.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -38,7 +38,7 @@ func (r *initMessageTextResource) Metadata(_ context.Context, req resource.Metad
 	resp.TypeName = req.ProviderTypeName + "_init_message_text"
 }
 
-func (r *initMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *initMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	return text.GenSchemaMessageCustomText(ctx)
 }
 
@@ -220,7 +220,7 @@ func getID(ctx context.Context, obj types.Object) (string, string) {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), helper.OrgIDVar), helper.GetStringFromAttr(ctx, obj.Attributes(), LanguageVar)
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (string, string) {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(plan.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {
@@ -235,7 +235,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (
 	return orgID, language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) (string, string) {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(state.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {

--- a/zitadel/login_texts/resource.go
+++ b/zitadel/login_texts/resource.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -38,7 +38,7 @@ func (r *loginTextsResource) Metadata(_ context.Context, req resource.MetadataRe
 	resp.TypeName = req.ProviderTypeName + "_login_texts"
 }
 
-func (r *loginTextsResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *loginTextsResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	return text.GenSchemaLoginCustomText(ctx)
 }
 
@@ -220,7 +220,7 @@ func getID(ctx context.Context, obj types.Object) (string, string) {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), helper.OrgIDVar), helper.GetStringFromAttr(ctx, obj.Attributes(), LanguageVar)
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (string, string) {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(plan.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {
@@ -235,7 +235,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (
 	return orgID, language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) (string, string) {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(state.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {

--- a/zitadel/password_change_message_text/resource.go
+++ b/zitadel/password_change_message_text/resource.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -38,7 +38,7 @@ func (r *passwordChangeMessageTextResource) Metadata(_ context.Context, req reso
 	resp.TypeName = req.ProviderTypeName + "_password_change_message_text"
 }
 
-func (r *passwordChangeMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *passwordChangeMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	return text.GenSchemaMessageCustomText(ctx)
 }
 
@@ -220,7 +220,7 @@ func getID(ctx context.Context, obj types.Object) (string, string) {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), helper.OrgIDVar), helper.GetStringFromAttr(ctx, obj.Attributes(), LanguageVar)
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (string, string) {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(plan.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {
@@ -235,7 +235,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (
 	return orgID, language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) (string, string) {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(state.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {

--- a/zitadel/password_reset_message_text/resource.go
+++ b/zitadel/password_reset_message_text/resource.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -38,7 +38,7 @@ func (r *passwordResetMessageTextResource) Metadata(_ context.Context, req resou
 	resp.TypeName = req.ProviderTypeName + "_password_reset_message_text"
 }
 
-func (r *passwordResetMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *passwordResetMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	return text.GenSchemaMessageCustomText(ctx)
 }
 
@@ -220,7 +220,7 @@ func getID(ctx context.Context, obj types.Object) (string, string) {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), helper.OrgIDVar), helper.GetStringFromAttr(ctx, obj.Attributes(), LanguageVar)
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (string, string) {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(plan.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {
@@ -235,7 +235,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (
 	return orgID, language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) (string, string) {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(state.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {

--- a/zitadel/passwordless_registration_message_text/resource.go
+++ b/zitadel/passwordless_registration_message_text/resource.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -38,7 +38,7 @@ func (r *passwordlessRegistrationMessageTextResource) Metadata(_ context.Context
 	resp.TypeName = req.ProviderTypeName + "_passwordless_registration_message_text"
 }
 
-func (r *passwordlessRegistrationMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *passwordlessRegistrationMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	return text.GenSchemaMessageCustomText(ctx)
 }
 
@@ -220,7 +220,7 @@ func getID(ctx context.Context, obj types.Object) (string, string) {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), helper.OrgIDVar), helper.GetStringFromAttr(ctx, obj.Attributes(), LanguageVar)
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (string, string) {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(plan.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {
@@ -235,7 +235,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (
 	return orgID, language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) (string, string) {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(state.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {

--- a/zitadel/provider.go
+++ b/zitadel/provider.go
@@ -7,7 +7,7 @@ import (
 	fdiag "github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -122,9 +122,9 @@ type providerModel struct {
 func (p *providerPV6) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
 	resp.TypeName = "zitadel"
 }
-func (p *providerPV6) GetSchema(_ context.Context) (tfsdk.Schema, fdiag.Diagnostics) {
-	return tfsdk.Schema{
-		Attributes: map[string]tfsdk.Attribute{
+func (p *providerPV6) Schema(_ context.Context, _ provider.SchemaRequest, resp *provider.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
 			helper.DomainVar: {
 				Type:        types.StringType,
 				Required:    true,
@@ -161,7 +161,7 @@ func (p *providerPV6) GetSchema(_ context.Context) (tfsdk.Schema, fdiag.Diagnost
 				Description: helper.PortDescription,
 			},
 		},
-	}, nil
+	}
 }
 
 func (p *providerPV6) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {

--- a/zitadel/verify_email_message_text/resource.go
+++ b/zitadel/verify_email_message_text/resource.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -38,7 +38,7 @@ func (r *verifyEmailMessageTextResource) Metadata(_ context.Context, req resourc
 	resp.TypeName = req.ProviderTypeName + "_verify_email_message_text"
 }
 
-func (r *verifyEmailMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *verifyEmailMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	return text.GenSchemaMessageCustomText(ctx)
 }
 
@@ -220,7 +220,7 @@ func getID(ctx context.Context, obj types.Object) (string, string) {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), helper.OrgIDVar), helper.GetStringFromAttr(ctx, obj.Attributes(), LanguageVar)
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (string, string) {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(plan.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {
@@ -235,7 +235,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (
 	return orgID, language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) (string, string) {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(state.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {

--- a/zitadel/verify_email_otp_message_text/resource.go
+++ b/zitadel/verify_email_otp_message_text/resource.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -38,7 +38,7 @@ func (r *verifyEmailOTPMessageTextResource) Metadata(_ context.Context, req reso
 	resp.TypeName = req.ProviderTypeName + "_verify_email_otp_message_text"
 }
 
-func (r *verifyEmailOTPMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *verifyEmailOTPMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	return text.GenSchemaMessageCustomText(ctx)
 }
 
@@ -220,7 +220,7 @@ func getID(ctx context.Context, obj types.Object) (string, string) {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), helper.OrgIDVar), helper.GetStringFromAttr(ctx, obj.Attributes(), LanguageVar)
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (string, string) {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(plan.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {
@@ -235,7 +235,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (
 	return orgID, language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) (string, string) {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(state.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {

--- a/zitadel/verify_phone_message_text/resource.go
+++ b/zitadel/verify_phone_message_text/resource.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -38,7 +38,7 @@ func (r *verifyPhoneMessageTextResource) Metadata(_ context.Context, req resourc
 	resp.TypeName = req.ProviderTypeName + "_verify_phone_message_text"
 }
 
-func (r *verifyPhoneMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *verifyPhoneMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	return text.GenSchemaMessageCustomText(ctx)
 }
 
@@ -220,7 +220,7 @@ func getID(ctx context.Context, obj types.Object) (string, string) {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), helper.OrgIDVar), helper.GetStringFromAttr(ctx, obj.Attributes(), LanguageVar)
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (string, string) {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(plan.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {
@@ -235,7 +235,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (
 	return orgID, language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) (string, string) {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(state.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {

--- a/zitadel/verify_sms_otp_message_text/resource.go
+++ b/zitadel/verify_sms_otp_message_text/resource.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/management"
 	textpb "github.com/zitadel/zitadel-go/v3/pkg/client/zitadel/text"
@@ -38,7 +38,7 @@ func (r *verifySMSOTPMessageTextResource) Metadata(_ context.Context, req resour
 	resp.TypeName = req.ProviderTypeName + "_verify_sms_otp_message_text"
 }
 
-func (r *verifySMSOTPMessageTextResource) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (r *verifySMSOTPMessageTextResource) Schema(ctx context.Context) (schema.Schema, diag.Diagnostics) {
 	return text.GenSchemaMessageCustomText(ctx)
 }
 
@@ -220,7 +220,7 @@ func getID(ctx context.Context, obj types.Object) (string, string) {
 	return helper.GetStringFromAttr(ctx, obj.Attributes(), helper.OrgIDVar), helper.GetStringFromAttr(ctx, obj.Attributes(), LanguageVar)
 }
 
-func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (string, string) {
+func getPlanAttrs(ctx context.Context, plan resource.Plan, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(plan.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {
@@ -235,7 +235,7 @@ func getPlanAttrs(ctx context.Context, plan tfsdk.Plan, diag diag.Diagnostics) (
 	return orgID, language
 }
 
-func getStateAttrs(ctx context.Context, state tfsdk.State, diag diag.Diagnostics) (string, string) {
+func getStateAttrs(ctx context.Context, state resource.State, diag diag.Diagnostics) (string, string) {
 	var orgID string
 	diag.Append(state.GetAttribute(ctx, path.Root(helper.OrgIDVar), &orgID)...)
 	if diag.HasError() {


### PR DESCRIPTION
## Summary
- migrate provider to use `schema.Schema` APIs
- update provider `Schema` method implementation
- switch provider server entrypoint to `providerserver.Serve`
- adjust tests to use new provider server
- bump terraform-plugin-framework module

## Testing
- `go mod tidy` *(fails: no route to host)*